### PR TITLE
Use global constants throughout the entire library

### DIFF
--- a/lib/constants.h
+++ b/lib/constants.h
@@ -17,6 +17,7 @@
  */
 
 //This header defines all the constants that are globally available in the library.
+#include <sodium.h>
 
 #ifndef LIB_CONSTANTS_H
 #define LIB_CONSTANTS_H
@@ -24,4 +25,15 @@
 #define CONVERSATION_ID_SIZE 32U //length of a conversation id in bytes
 #define PREKEY_AMOUNT 100U //number of prekeys that are used
 
+//key sizes
+#define CHAIN_KEY_SIZE crypto_secretbox_KEYBYTES
+#define MESSAGE_KEY_SIZE crypto_secretbox_KEYBYTES
+#define HEADER_KEY_SIZE crypto_aead_chacha20poly1305_KEYBYTES
+#define ROOT_KEY_SIZE crypto_secretbox_KEYBYTES
+#define PRIVATE_KEY_SIZE crypto_box_SECRETKEYBYTES
+#define PUBLIC_KEY_SIZE crypto_box_PUBLICKEYBYTES
+
+//nonce sizes
+#define MESSAGE_NONCE_SIZE crypto_secretbox_NONCEBYTES
+#define HEADER_NONCE_SIZE crypto_aead_chacha20poly1305_NPUBBYTES
 #endif

--- a/lib/constants.h
+++ b/lib/constants.h
@@ -1,0 +1,27 @@
+/* Molch, an implementation of the axolotl ratchet based on libsodium
+ *  Copyright (C) 2015  Max Bruckner (FSMaxB)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+//This header defines all the constants that are globally available in the library.
+
+#ifndef LIB_CONSTANTS_H
+#define LIB_CONSTANTS_H
+
+#define CONVERSATION_ID_SIZE 32U //length of a conversation id in bytes
+#define PREKEY_AMOUNT 100U //number of prekeys that are used
+
+#endif

--- a/lib/conversation.h
+++ b/lib/conversation.h
@@ -16,12 +16,11 @@
  *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "constants.h"
 #include "ratchet.h"
 
 #ifndef LIB_CONVERSATION_H
 #define LIB_CONVERSATION_H
-
-#define CONVERSATION_ID_SIZE 32
 
 typedef struct conversation_t {
 	buffer_t id[1]; //unique id of a conversation, generated randomly

--- a/lib/diffie-hellman.c
+++ b/lib/diffie-hellman.c
@@ -18,6 +18,7 @@
 #include <sodium.h>
 #include <assert.h>
 
+#include "constants.h"
 #include "diffie-hellman.h"
 
 /*
@@ -35,25 +36,25 @@
  */
 int diffie_hellman(
 		buffer_t * const derived_key, //needs to be crypto_generichash_BYTES long
-		const buffer_t * const our_private_key, //needs to be crypto_box_SECRETKEYBYTES long
-		const buffer_t * const our_public_key, //needs to be crypto_box_PUBLICKEYBYTES long
-		const buffer_t * const their_public_key, //needs to be crypto_box_PUBLICKEYBYTES long
+		const buffer_t * const our_private_key, //needs to be PRIVATE_KEY_SIZE long
+		const buffer_t * const our_public_key, //needs to be PUBLIC_KEY_SIZE long
+		const buffer_t * const their_public_key, //needs to be PUBLIC_KEY_SIZE long
 		const bool am_i_alice) {
 	//make sure that the assumptions are correct
-	assert(crypto_box_PUBLICKEYBYTES == crypto_scalarmult_SCALARBYTES);
-	assert(crypto_box_SECRETKEYBYTES == crypto_scalarmult_SCALARBYTES);
+	assert(PUBLIC_KEY_SIZE == crypto_scalarmult_SCALARBYTES);
+	assert(PRIVATE_KEY_SIZE == crypto_scalarmult_SCALARBYTES);
 
 	//set content length of output to 0 (can prevent use on failure)
 	derived_key->content_length = 0;
 
 	//check buffer sizes
 	if ((derived_key->buffer_length < crypto_generichash_BYTES)
-			|| (our_private_key->content_length != crypto_box_SECRETKEYBYTES)
-			|| (our_public_key->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (their_public_key->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (our_private_key->buffer_length < crypto_box_SECRETKEYBYTES)
-			|| (our_public_key->buffer_length < crypto_box_PUBLICKEYBYTES)
-			|| (their_public_key->buffer_length < crypto_box_PUBLICKEYBYTES)) {
+			|| (our_private_key->content_length != PRIVATE_KEY_SIZE)
+			|| (our_public_key->content_length != PUBLIC_KEY_SIZE)
+			|| (their_public_key->content_length != PUBLIC_KEY_SIZE)
+			|| (our_private_key->buffer_length < PRIVATE_KEY_SIZE)
+			|| (our_public_key->buffer_length < PUBLIC_KEY_SIZE)
+			|| (their_public_key->buffer_length < PUBLIC_KEY_SIZE)) {
 		return -6;
 	}
 
@@ -161,18 +162,18 @@ int triple_diffie_hellman(
 
 	//check buffer sizes
 	if ((derived_key->buffer_length < crypto_generichash_BYTES)
-			|| (our_private_identity->content_length != crypto_box_SECRETKEYBYTES)
-			|| (our_public_identity->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (their_public_identity->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (our_private_ephemeral->content_length != crypto_box_SECRETKEYBYTES)
-			|| (our_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (their_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (our_private_identity->buffer_length < crypto_box_SECRETKEYBYTES)
-			|| (our_public_identity->buffer_length < crypto_box_PUBLICKEYBYTES)
-			|| (their_public_identity->buffer_length < crypto_box_PUBLICKEYBYTES)
-			|| (our_private_ephemeral->buffer_length < crypto_box_SECRETKEYBYTES)
-			|| (our_public_ephemeral->buffer_length < crypto_box_PUBLICKEYBYTES)
-			|| (their_public_ephemeral->buffer_length < crypto_box_PUBLICKEYBYTES)) {
+			|| (our_private_identity->content_length != PRIVATE_KEY_SIZE)
+			|| (our_public_identity->content_length != PUBLIC_KEY_SIZE)
+			|| (their_public_identity->content_length != PUBLIC_KEY_SIZE)
+			|| (our_private_ephemeral->content_length != PRIVATE_KEY_SIZE)
+			|| (our_public_ephemeral->content_length != PUBLIC_KEY_SIZE)
+			|| (their_public_ephemeral->content_length != PUBLIC_KEY_SIZE)
+			|| (our_private_identity->buffer_length < PRIVATE_KEY_SIZE)
+			|| (our_public_identity->buffer_length < PUBLIC_KEY_SIZE)
+			|| (their_public_identity->buffer_length < PUBLIC_KEY_SIZE)
+			|| (our_private_ephemeral->buffer_length < PRIVATE_KEY_SIZE)
+			|| (our_public_ephemeral->buffer_length < PUBLIC_KEY_SIZE)
+			|| (their_public_ephemeral->buffer_length < PUBLIC_KEY_SIZE)) {
 		return -6;
 	}
 

--- a/lib/diffie-hellman.h
+++ b/lib/diffie-hellman.h
@@ -38,9 +38,9 @@
  */
 int diffie_hellman(
 		buffer_t * const derived_key, //needs to be crypto_generichash_BYTES long
-		const buffer_t * const our_private_key, //needs to be crypto_box_SECRETKEYBYTES long
-		const buffer_t * const our_public_key, //needs to be crypto_box_PUBLICKEYBYTES long
-		const buffer_t * const their_public_key, //needs to be crypto_box_PUBLICKEYBYTES long
+		const buffer_t * const our_private_key, //needs to be PRIVATE_KEY_SIZE long
+		const buffer_t * const our_public_key, //needs to be PUBLIC_KEY_SIZE long
+		const buffer_t * const their_public_key, //needs to be PUBLIC_KEY_SIZE long
 		const bool am_i_alice) __attribute__((warn_unused_result));
 
 /*

--- a/lib/header-and-message-keystore.c
+++ b/lib/header-and-message-keystore.c
@@ -18,6 +18,7 @@
 
 #include <string.h>
 
+#include "constants.h"
 #include "header-and-message-keystore.h"
 
 //create new keystore
@@ -37,8 +38,8 @@ header_and_message_keystore_node *create_node() {
 	}
 
 	//initialise buffers with storage arrays
-	buffer_init_with_pointer(node->message_key, node->message_key_storage, crypto_secretbox_KEYBYTES, 0);
-	buffer_init_with_pointer(node->header_key, node->header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, 0);
+	buffer_init_with_pointer(node->message_key, node->message_key_storage, MESSAGE_KEY_SIZE, 0);
+	buffer_init_with_pointer(node->header_key, node->header_key_storage, HEADER_KEY_SIZE, 0);
 
 	return node;
 }
@@ -75,8 +76,8 @@ int header_and_message_keystore_add(
 		const buffer_t * const message_key,
 		const buffer_t * const header_key) {
 	//check buffer sizes
-	if ((message_key->content_length != crypto_secretbox_KEYBYTES)
-			|| (header_key->content_length != crypto_aead_chacha20poly1305_KEYBYTES)) {
+	if ((message_key->content_length != MESSAGE_KEY_SIZE)
+			|| (header_key->content_length != HEADER_KEY_SIZE)) {
 		return -6;
 	}
 
@@ -226,8 +227,8 @@ int header_and_message_keystore_json_import(
 		mcJSON *timestamp = mcJSON_GetObjectItem(key, timestamp_string);
 
 		//check if they are valid
-		if ((message_key == NULL) || (message_key->type != mcJSON_String) || (message_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))
-				|| (header_key == NULL) || (header_key->type != mcJSON_String) || (header_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))
+		if ((message_key == NULL) || (message_key->type != mcJSON_String) || (message_key->valuestring->content_length != (2 * MESSAGE_KEY_SIZE + 1))
+				|| (header_key == NULL) || (header_key->type != mcJSON_String) || (header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
 				|| (timestamp == NULL) || (timestamp->type != mcJSON_Number)) {
 			header_and_message_keystore_clear(keystore);
 			return -3;

--- a/lib/header-and-message-keystore.h
+++ b/lib/header-and-message-keystore.h
@@ -19,6 +19,7 @@
 #include <sodium.h>
 #include <time.h>
 
+#include "constants.h"
 #include "../buffer/buffer.h"
 #include "../mcJSON/mcJSON.h"
 
@@ -33,9 +34,9 @@ struct header_and_message_keystore_node {
 	header_and_message_keystore_node *previous;
 	header_and_message_keystore_node *next;
 	buffer_t message_key[1];
-	unsigned char message_key_storage[crypto_secretbox_KEYBYTES];
+	unsigned char message_key_storage[MESSAGE_KEY_SIZE];
 	buffer_t header_key[1];
-	unsigned char header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	unsigned char header_key_storage[HEADER_KEY_SIZE];
 	time_t timestamp;
 };
 

--- a/lib/header.c
+++ b/lib/header.c
@@ -19,6 +19,7 @@
 #include <string.h>
 #include <assert.h>
 
+#include "constants.h"
 #include "header.h"
 
 /*
@@ -26,19 +27,19 @@
  *
  * The header looks like follows:
  * header (40) = {
- *   public_ephemeral_key (crypto_box_PUBLICKEYBYTES = 32),
+ *   public_ephemeral_key (PUBLIC_KEY_SIZE = 32),
  *   message_counter (4)
  *   previous_message_counter(4)
  * }
  */
 int header_construct(
-		buffer_t * const header, //crypto_box_PUBLICKEYBYTES + 8
-		const buffer_t * const our_public_ephemeral, //crypto_box_PUBLICKEYBYTES
+		buffer_t * const header, //PUBLIC_KEY_SIZE + 8
+		const buffer_t * const our_public_ephemeral, //PUBLIC_KEY_SIZE
 		const uint32_t message_counter,
 		const uint32_t previous_message_counter) { //FIXME: Endianness
 	//check buffer sizes
-	if ((header->buffer_length < crypto_box_PUBLICKEYBYTES + 8)
-			|| (our_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)) {
+	if ((header->buffer_length < PUBLIC_KEY_SIZE + 8)
+			|| (our_public_ephemeral->content_length != PUBLIC_KEY_SIZE)) {
 		header->content_length = 0;
 		return -6;
 	}
@@ -48,12 +49,12 @@ int header_construct(
 		buffer_clear(header);
 		return status;
 	}
-	status = buffer_copy_from_raw(header, crypto_box_PUBLICKEYBYTES, (unsigned char*) &message_counter, 0, sizeof(message_counter));
+	status = buffer_copy_from_raw(header, PUBLIC_KEY_SIZE, (unsigned char*) &message_counter, 0, sizeof(message_counter));
 	if (status != 0) {
 		buffer_clear(header);
 		return status;
 	}
-	status = buffer_copy_from_raw(header, crypto_box_PUBLICKEYBYTES + sizeof(message_counter), (unsigned char*) &previous_message_counter, 0, sizeof(previous_message_counter));
+	status = buffer_copy_from_raw(header, PUBLIC_KEY_SIZE + sizeof(message_counter), (unsigned char*) &previous_message_counter, 0, sizeof(previous_message_counter));
 	if (status != 0) {
 		buffer_clear(header);
 		return status;
@@ -66,25 +67,25 @@ int header_construct(
  * Get the content of the header.
  */
 int header_extract(
-		const buffer_t * const header, //crypto_box_PUBLICKEYBYTES + 8, input
-		buffer_t * const their_public_ephemeral, //crypto_box_PUBLICKEYBYTES, output
+		const buffer_t * const header, //PUBLIC_KEY_SIZE + 8, input
+		buffer_t * const their_public_ephemeral, //PUBLIC_KEY_SIZE, output
 		uint32_t * const message_counter,
 		uint32_t * const previous_message_counter) { //FIXME Endianness
 	//check buffer sizes
-	if ((header->content_length != crypto_box_PUBLICKEYBYTES + 8)
-			|| (their_public_ephemeral->buffer_length < crypto_box_PUBLICKEYBYTES)) {
+	if ((header->content_length != PUBLIC_KEY_SIZE + 8)
+			|| (their_public_ephemeral->buffer_length < PUBLIC_KEY_SIZE)) {
 		their_public_ephemeral->content_length = 0;
 		return -6;
 	}
 
 	int status;
-	status = buffer_copy(their_public_ephemeral, 0, header, 0, crypto_box_PUBLICKEYBYTES);
+	status = buffer_copy(their_public_ephemeral, 0, header, 0, PUBLIC_KEY_SIZE);
 	if (status != 0) {
 		buffer_clear(their_public_ephemeral);
 		return status;
 	}
-	*message_counter = *(uint32_t*) (header->content + crypto_box_PUBLICKEYBYTES);
-	*previous_message_counter = *(uint32_t*) (header->content + crypto_box_PUBLICKEYBYTES + sizeof(uint32_t));
+	*message_counter = *(uint32_t*) (header->content + PUBLIC_KEY_SIZE);
+	*previous_message_counter = *(uint32_t*) (header->content + PUBLIC_KEY_SIZE + sizeof(uint32_t));
 
 	return 0;
 }

--- a/lib/header.h
+++ b/lib/header.h
@@ -26,14 +26,14 @@
  *
  * The header looks like follows:
  * header (40) = {
- *   public_ephemeral_key (crypto_box_PUBLICKEYBYTES = 32),
+ *   public_ephemeral_key (PUBLIC_KEY_SIZE = 32),
  *   message_counter (4)
  *   previous_message_counter(4)
  * }
  */
 int header_construct(
-		buffer_t * const header, //crypto_box_PUBLICKEYBYTES + 8, output
-		const buffer_t * const our_public_ephemeral, //crypto_box_PUBLICKEYBYTES
+		buffer_t * const header, //PUBLIC_KEY_SIZE + 8, output
+		const buffer_t * const our_public_ephemeral, //PUBLIC_KEY_SIZE
 		const uint32_t message_counter,
 		const uint32_t previous_message_counter) __attribute__((warn_unused_result));
 
@@ -41,8 +41,8 @@ int header_construct(
  * Get the content of the header.
  */
 int header_extract(
-		const buffer_t * const header, //crypto_box_PUBLICKEYBYTES + 8, input
-		buffer_t * const their_public_ephemeral, //crypto_box_PUBLICKEYBYTES, output
+		const buffer_t * const header, //PUBLIC_KEY_SIZE+ 8, input
+		buffer_t * const their_public_ephemeral, //PUBLIC_KEY_SIZE, output
 		uint32_t * const message_counter,
 		uint32_t * const previous_message_counter) __attribute__((warn_unused_result));
 #endif

--- a/lib/key-derivation.h
+++ b/lib/key-derivation.h
@@ -66,9 +66,9 @@ int derive_message_key(
  * RK, CK, HK = KDF( RK, DH(DHRr, DHRs) )
  */
 int derive_root_chain_and_header_keys(
-		buffer_t * const root_key, //crypto_secretbox_KEYBYTES
-		buffer_t * const chain_key, //crypto_secretbox_KEYBYTES
-		buffer_t * const header_key, //crypto_aead_chacha20poly1305_KEYBYTES
+		buffer_t * const root_key, //ROOT_KEY_SIZE
+		buffer_t * const chain_key, //CHAIN_KEY_SIZE
+		buffer_t * const header_key, //HEADER_KEY_SIZE
 		const buffer_t * const our_private_ephemeral,
 		const buffer_t * const our_public_ephemeral,
 		const buffer_t * const their_public_ephemeral,
@@ -81,13 +81,13 @@ int derive_root_chain_and_header_keys(
  * RK, CKs/r, HKs/r = KDF(HASH(DH(A,B0) || DH(A0,B) || DH(A0,B0)))
  */
 int derive_initial_root_chain_and_header_keys(
-		buffer_t * const root_key, //crypto_secretbox_KEYBYTES
-		buffer_t * const send_chain_key, //crypto_secretbox_KEYBYTES
-		buffer_t * const receive_chain_key, //crypto_secretbox_KEYBYTES
-		buffer_t * const send_header_key, //crypto_aead_chacha20poly1305_KEYBYTES
-		buffer_t * const receive_header_key, //crypto_aead_chacha20poly1305_KEYBYTES
-		buffer_t * const next_send_header_key, //crypto_aead_chacha20poly1305_KEYBYTES
-		buffer_t * const next_receive_header_key, //crypto_aead_chacha20poly1305_KEYBYTES
+		buffer_t * const root_key, //ROOT_KEY_SIZE
+		buffer_t * const send_chain_key, //CHAIN_KEY_SIZE
+		buffer_t * const receive_chain_key, //CHAIN_KEY_SIZE
+		buffer_t * const send_header_key, //HEADER_KEY_SIZE
+		buffer_t * const receive_header_key, //HEADER_KEY_SIZE
+		buffer_t * const next_send_header_key, //HEADER_KEY_SIZE
+		buffer_t * const next_receive_header_key, //HEADER_KEY_SIZE
 		const buffer_t * const our_private_identity,
 		const buffer_t * const our_public_identity,
 		const buffer_t * const their_public_identity,

--- a/lib/molch.h
+++ b/lib/molch.h
@@ -42,8 +42,8 @@
  * Returns 0 on success.
  */
 int molch_create_user(
-		unsigned char * const public_identity_key, //output, crypto_box_PUBLICKEYBYTES
-		unsigned char * const prekey_list, //output, needs to be 100 * crypto_box_PUBLICKEYBYTES + crypto_onetimeauth_BYTES
+		unsigned char * const public_identity_key, //output, PUBLIC_KEY_SIZE
+		unsigned char * const prekey_list, //output, needs to be 100 * PUBLIC_KEY_SIZE + crypto_onetimeauth_BYTES
 		const unsigned char * const random_data,
 		const size_t random_data_length) __attribute__((warn_unused_result));
 
@@ -98,10 +98,10 @@ int molch_create_send_conversation(
 		size_t *packet_length, //output
 		const unsigned char * const message,
 		const size_t message_length,
-		const unsigned char * const prekey_list, //prekey list of the receiver (PREKEY_AMOUNT * crypto_box_PUBLICKEYBYTES)
+		const unsigned char * const prekey_list, //prekey list of the receiver (PREKEY_AMOUNT * PUBLIC_KEY_SIZE)
 		const unsigned char * const sender_public_identity, //identity of the sender (user)
 		const unsigned char * const receiver_public_identity) __attribute__((warn_unused_result));  //identity of the receiver
-//prekeys of the receiver (PREKEY_AMOUNT * crypto_box_PUBLICKEYBYTES)
+//prekeys of the receiver (PREKEY_AMOUNT * PUBLIC_KEY_SIZE)
 
 /*
  * Start a new conversation. (receiving)
@@ -122,7 +122,7 @@ int molch_create_receive_conversation(
 		size_t * const message_length, //output
 		const unsigned char * const packet, //received prekey packet
 		const size_t packet_length,
-		unsigned char * const prekey_list, //output, needs to be PREKEY_AMOUNT * crypto_box_PUBLICKEYBYTES + crypto_onetimeauth_BYTES, This is the new prekey list for the receiving user
+		unsigned char * const prekey_list, //output, needs to be PREKEY_AMOUNT * PUBLIC_KEY_SIZE + crypto_onetimeauth_BYTES, This is the new prekey list for the receiving user
 		const unsigned char * const sender_public_identity, //identity of the sender
 		const unsigned char * const receiver_public_identity) __attribute__((warn_unused_result)); //identity key of the receiver (user)
 

--- a/lib/packet.h
+++ b/lib/packet.h
@@ -37,10 +37,10 @@
  *   protocol_version(1), //4MSB: current version; 4LSB: highest supported version
  *   packet_type(1),
  *   header_length(1),
- *   header_nonce(crypto_aead_chacha20poly1305_NPUBBYTES),
+ *   header_nonce(HEADER_NONCE_SIZE),
  *   header {
  *       axolotl_header(?),
- *       message_nonce(crypto_secretbox_NONCEBYTES)
+ *       message_nonce(MESSAGE_NONCE_SIZE)
  *   },
  *   header_and_additional_data_MAC(crypto_aead_chacha20poly1305_ABYTES),
  *   authenticated_encrypted_message {
@@ -55,9 +55,9 @@ int packet_encrypt(
 		const unsigned char current_protocol_version, //this can't be larger than 0xF = 15
 		const unsigned char highest_supported_protocol_version, //this can't be larger than 0xF = 15
 		const buffer_t * const header,
-		const buffer_t * const header_key, //crypto_aead_chacha20poly1305_KEYBYTES
+		const buffer_t * const header_key, //HEADER_KEY_SIZE
 		const buffer_t * const message,
-		const buffer_t * const message_key) __attribute__((warn_unused_result)); //crypto_secretbox_KEYBYTES
+		const buffer_t * const message_key) __attribute__((warn_unused_result)); //MESSAGE_KEY_SIZE
 
 /*
  * Decrypt and authenticate a packet.
@@ -68,9 +68,9 @@ int packet_decrypt(
 		unsigned char * const current_protocol_version, //1 Byte, no array
 		unsigned char * const highest_supported_protocol_version, //1 Byte, no array
 		buffer_t * const header, //output, As long as the packet or at most 255 bytes
-		const buffer_t * const header_key, //crypto_aead_chacha20poly1305_KEYBYTES
+		const buffer_t * const header_key, //HEADER_KEY_SIZE
 		buffer_t * const message, //output, should be as long as the packet
-		const buffer_t * const message_key) __attribute__((warn_unused_result)); //crypto_secretbox_KEYBYTES
+		const buffer_t * const message_key) __attribute__((warn_unused_result)); //MESSAGE_KEY_SIZE
 
 /*
  * Get the metadata of a packet (without verifying it's authenticity).
@@ -89,7 +89,7 @@ int packet_decrypt_header(
 		const buffer_t * const packet,
 		buffer_t * const header, //As long as the packet or at most 255 bytes
 		buffer_t * const message_nonce, //output
-		const buffer_t * const header_key) __attribute__((warn_unused_result)); //crypto_aead_chacha20poly1305_KEYBYTES
+		const buffer_t * const header_key) __attribute__((warn_unused_result)); //HEADER_KEY_SIZE
 
 /*
  * Decrypt the message inside a packet.
@@ -100,6 +100,6 @@ int packet_decrypt_message(
 		const buffer_t * const packet,
 		buffer_t * const message, //This buffer should be as large as the packet
 		const buffer_t * const message_nonce,
-		const buffer_t * const message_key) __attribute__((warn_unused_result)); //crypto_secretbox_KEYBYTES
+		const buffer_t * const message_key) __attribute__((warn_unused_result)); //MESSAGE_KEY_SIZE
 
 #endif

--- a/lib/ratchet.c
+++ b/lib/ratchet.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 #include <stdint.h>
 
+#include "constants.h"
 #include "ratchet.h"
 #include "diffie-hellman.h"
 #include "key-derivation.h"
@@ -44,27 +45,27 @@ ratchet_state *create_ratchet_state() {
 	}
 
 	//initialize the buffers with the storage arrays
-	buffer_init_with_pointer(state->root_key, (unsigned char*)state->root_key_storage, crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
-	buffer_init_with_pointer(state->purported_root_key, (unsigned char*)state->purported_root_key_storage, crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+	buffer_init_with_pointer(state->root_key, (unsigned char*)state->root_key_storage, ROOT_KEY_SIZE, ROOT_KEY_SIZE);
+	buffer_init_with_pointer(state->purported_root_key, (unsigned char*)state->purported_root_key_storage, ROOT_KEY_SIZE, ROOT_KEY_SIZE);
 	//header keys
-	buffer_init_with_pointer(state->send_header_key, (unsigned char*)state->send_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->receive_header_key, (unsigned char*)state->receive_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->next_send_header_key, (unsigned char*)state->next_send_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->next_receive_header_key, (unsigned char*)state->next_receive_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->purported_receive_header_key, (unsigned char*)state->purported_receive_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->purported_next_receive_header_key, (unsigned char*)state->purported_next_receive_header_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
+	buffer_init_with_pointer(state->send_header_key, (unsigned char*)state->send_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
+	buffer_init_with_pointer(state->receive_header_key, (unsigned char*)state->receive_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
+	buffer_init_with_pointer(state->next_send_header_key, (unsigned char*)state->next_send_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
+	buffer_init_with_pointer(state->next_receive_header_key, (unsigned char*)state->next_receive_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
+	buffer_init_with_pointer(state->purported_receive_header_key, (unsigned char*)state->purported_receive_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
+	buffer_init_with_pointer(state->purported_next_receive_header_key, (unsigned char*)state->purported_next_receive_header_key_storage, HEADER_KEY_SIZE, HEADER_KEY_SIZE);
 	//chain keys
-	buffer_init_with_pointer(state->send_chain_key, (unsigned char*)state->send_chain_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->receive_chain_key, (unsigned char*)state->receive_chain_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->purported_receive_chain_key, (unsigned char*)state->purported_receive_chain_key_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
+	buffer_init_with_pointer(state->send_chain_key, (unsigned char*)state->send_chain_key_storage, CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
+	buffer_init_with_pointer(state->receive_chain_key, (unsigned char*)state->receive_chain_key_storage, CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
+	buffer_init_with_pointer(state->purported_receive_chain_key, (unsigned char*)state->purported_receive_chain_key_storage, CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
 	//identity keys
-	buffer_init_with_pointer(state->our_public_identity, (unsigned char*)state->our_public_identity_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->their_public_identity, (unsigned char*)state->their_public_identity_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
+	buffer_init_with_pointer(state->our_public_identity, (unsigned char*)state->our_public_identity_storage, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
+	buffer_init_with_pointer(state->their_public_identity, (unsigned char*)state->their_public_identity_storage, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
 	//ephemeral keys (ratchet keys)
-	buffer_init_with_pointer(state->our_private_ephemeral, (unsigned char*)state->our_private_ephemeral_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->our_public_ephemeral, (unsigned char*)state->our_public_ephemeral_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->their_public_ephemeral, (unsigned char*)state->their_public_ephemeral_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
-	buffer_init_with_pointer(state->their_purported_public_ephemeral, (unsigned char*)state->their_purported_public_ephemeral_storage, crypto_aead_chacha20poly1305_KEYBYTES, crypto_aead_chacha20poly1305_KEYBYTES);
+	buffer_init_with_pointer(state->our_private_ephemeral, (unsigned char*)state->our_private_ephemeral_storage, PRIVATE_KEY_SIZE, PRIVATE_KEY_SIZE);
+	buffer_init_with_pointer(state->our_public_ephemeral, (unsigned char*)state->our_public_ephemeral_storage, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
+	buffer_init_with_pointer(state->their_public_ephemeral, (unsigned char*)state->their_public_ephemeral_storage, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
+	buffer_init_with_pointer(state->their_purported_public_ephemeral, (unsigned char*)state->their_purported_public_ephemeral_storage, PUBLIC_KEY_SIZE, PUBLIC_KEY_SIZE);
 
 	//initialise message keystore for skipped messages
 	header_and_message_keystore_init(state->skipped_header_and_message_keys);
@@ -89,12 +90,12 @@ ratchet_state* ratchet_create(
 		const buffer_t * const our_public_ephemeral,
 		const buffer_t * const their_public_ephemeral) {
 	//check buffer sizes
-	if ((our_private_identity->content_length != crypto_box_SECRETKEYBYTES)
-			|| (our_public_identity->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (their_public_identity->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (our_private_ephemeral->content_length != crypto_box_SECRETKEYBYTES)
-			|| (our_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)
-			|| (their_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)) {
+	if ((our_private_identity->content_length != PRIVATE_KEY_SIZE)
+			|| (our_public_identity->content_length != PUBLIC_KEY_SIZE)
+			|| (their_public_identity->content_length != PUBLIC_KEY_SIZE)
+			|| (our_private_ephemeral->content_length != PRIVATE_KEY_SIZE)
+			|| (our_public_ephemeral->content_length != PUBLIC_KEY_SIZE)
+			|| (their_public_ephemeral->content_length != PUBLIC_KEY_SIZE)) {
 		return NULL;
 	}
 
@@ -200,7 +201,7 @@ int ratchet_next_send_keys(
 
 		//derive next root key and send chain key
 		//RK, CKs, NHKs = KDF(DH(DHs, DHr))
-		buffer_t *previous_root_key = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+		buffer_t *previous_root_key = buffer_create_on_heap(ROOT_KEY_SIZE, ROOT_KEY_SIZE);
 		status = buffer_clone(previous_root_key, state->root_key);
 		if (status != 0) {
 			buffer_destroy_from_heap(previous_root_key);
@@ -246,7 +247,7 @@ int ratchet_next_send_keys(
 
 	//derive next chain key
 	//CKs = HMAC-HASH(CKs, 0x01)
-	buffer_t *old_chain_key = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+	buffer_t *old_chain_key = buffer_create_on_heap(CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
 	status = buffer_clone(old_chain_key, state->send_chain_key);
 	if (status != 0) {
 		buffer_destroy_from_heap(old_chain_key);
@@ -276,8 +277,8 @@ int ratchet_get_receive_header_keys(
 		buffer_t * const next_receive_header_key,
 		ratchet_state *state) {
 	//check buffer sizes
-	if ((current_receive_header_key->buffer_length < crypto_aead_chacha20poly1305_KEYBYTES)
-			|| (next_receive_header_key->buffer_length < crypto_secretbox_KEYBYTES)) {
+	if ((current_receive_header_key->buffer_length < HEADER_KEY_SIZE)
+			|| (next_receive_header_key->buffer_length < HEADER_KEY_SIZE)) {
 		return -6;
 	}
 
@@ -339,9 +340,9 @@ int stage_skipped_header_and_message_keys(
 		const unsigned int purported_message_number,
 		const buffer_t * const receive_chain_key,
 		ratchet_state *state) {
-	if ((purported_chain_key->buffer_length < crypto_secretbox_KEYBYTES)
-			|| (message_key->buffer_length < crypto_secretbox_KEYBYTES)
-			|| (receive_chain_key->content_length != crypto_secretbox_KEYBYTES)) {
+	if ((purported_chain_key->buffer_length < CHAIN_KEY_SIZE)
+			|| (message_key->buffer_length < MESSAGE_KEY_SIZE)
+			|| (receive_chain_key->content_length != CHAIN_KEY_SIZE)) {
 		buffer_clear(message_key);
 		buffer_clear(purported_chain_key);
 		return -6;
@@ -362,10 +363,10 @@ int stage_skipped_header_and_message_keys(
 
 	int status;
 	//message key buffer
-	buffer_t *message_key_buffer = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+	buffer_t *message_key_buffer = buffer_create_on_heap(MESSAGE_KEY_SIZE, MESSAGE_KEY_SIZE);
 	//copy current chain key to purported chain key
-	buffer_t *purported_current_chain_key = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
-	buffer_t *purported_next_chain_key = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+	buffer_t *purported_current_chain_key = buffer_create_on_heap(CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
+	buffer_t *purported_next_chain_key = buffer_create_on_heap(CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
 	status = buffer_clone(purported_current_chain_key, receive_chain_key);
 	if (status != 0) {
 		goto cleanup;
@@ -465,8 +466,8 @@ int ratchet_receive(
 		const unsigned int purported_previous_message_number,
 		ratchet_state * const state) {
 	//check buffer sizes
-	if ((message_key->buffer_length < crypto_secretbox_KEYBYTES)
-			|| (their_purported_public_ephemeral->content_length != crypto_box_PUBLICKEYBYTES)) {
+	if ((message_key->buffer_length < MESSAGE_KEY_SIZE)
+			|| (their_purported_public_ephemeral->content_length != PUBLIC_KEY_SIZE)) {
 		return -6;
 	}
 
@@ -519,7 +520,7 @@ int ratchet_receive(
 		}
 
 		//temporary storage for the purported chain key (CKp)
-		buffer_t *temp_purported_chain_key = buffer_create_on_heap(crypto_secretbox_KEYBYTES, crypto_secretbox_KEYBYTES);
+		buffer_t *temp_purported_chain_key = buffer_create_on_heap(CHAIN_KEY_SIZE, CHAIN_KEY_SIZE);
 
 		//stage message keys for previous message chain
 		status = stage_skipped_header_and_message_keys(
@@ -641,7 +642,7 @@ int ratchet_set_last_message_authenticity(ratchet_state *state, bool valid) {
 		}
 		//erase(DHRs)
 		buffer_clear(state->our_private_ephemeral);
-		state->our_private_ephemeral->content_length = crypto_box_SECRETKEYBYTES; //TODO is this necessary?
+		state->our_private_ephemeral->content_length = PRIVATE_KEY_SIZE; //TODO is this necessary?
 		//ratchet_flag = True
 		state->ratchet_flag = true;
 	}
@@ -864,8 +865,8 @@ ratchet_state *ratchet_json_import(const mcJSON * const json) {
 	mcJSON *root_key = mcJSON_GetObjectItem(root_keys, root_key_string);
 	buffer_create_from_string(purported_root_key_string, "purported_root_key");
 	mcJSON *purported_root_key = mcJSON_GetObjectItem(root_keys, purported_root_key_string);
-	if ((root_key == NULL) || (root_key->type != mcJSON_String) || (root_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))
-			|| (purported_root_key == NULL) || (purported_root_key->type != mcJSON_String) || (purported_root_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))) {
+	if ((root_key == NULL) || (root_key->type != mcJSON_String) || (root_key->valuestring->content_length != (2 * ROOT_KEY_SIZE + 1))
+			|| (purported_root_key == NULL) || (purported_root_key->type != mcJSON_String) || (purported_root_key->valuestring->content_length != (2 * ROOT_KEY_SIZE + 1))) {
 		goto fail;
 	}
 
@@ -897,12 +898,12 @@ ratchet_state *ratchet_json_import(const mcJSON * const json) {
 	mcJSON *purported_receive_header_key = mcJSON_GetObjectItem(header_keys, purported_receive_header_key_string);
 	buffer_create_from_string(purported_next_receive_header_key_string, "purported_next_receive_header_key");
 	mcJSON *purported_next_receive_header_key = mcJSON_GetObjectItem(header_keys, purported_next_receive_header_key_string);
-	if ((send_header_key == NULL) || (send_header_key->type != mcJSON_String) || (send_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))
-			|| (receive_header_key == NULL) || (receive_header_key->type != mcJSON_String) || (receive_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))
-			|| (next_send_header_key == NULL) || (next_send_header_key->type != mcJSON_String) || (next_send_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))
-			|| (next_receive_header_key == NULL) || (next_receive_header_key->type != mcJSON_String) || (next_receive_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))
-			|| (purported_receive_header_key == NULL) || (purported_receive_header_key->type != mcJSON_String) || (purported_receive_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))
-			|| (purported_next_receive_header_key == NULL) || (purported_next_receive_header_key->type != mcJSON_String) || (purported_next_receive_header_key->valuestring->content_length != (2 * crypto_aead_chacha20poly1305_KEYBYTES + 1))) {
+	if ((send_header_key == NULL) || (send_header_key->type != mcJSON_String) || (send_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
+			|| (receive_header_key == NULL) || (receive_header_key->type != mcJSON_String) || (receive_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
+			|| (next_send_header_key == NULL) || (next_send_header_key->type != mcJSON_String) || (next_send_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
+			|| (next_receive_header_key == NULL) || (next_receive_header_key->type != mcJSON_String) || (next_receive_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
+			|| (purported_receive_header_key == NULL) || (purported_receive_header_key->type != mcJSON_String) || (purported_receive_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))
+			|| (purported_next_receive_header_key == NULL) || (purported_next_receive_header_key->type != mcJSON_String) || (purported_next_receive_header_key->valuestring->content_length != (2 * HEADER_KEY_SIZE + 1))) {
 		goto fail;
 	}
 
@@ -939,9 +940,9 @@ ratchet_state *ratchet_json_import(const mcJSON * const json) {
 	mcJSON *receive_chain_key = mcJSON_GetObjectItem(chain_keys, receive_chain_key_string);
 	buffer_create_from_string(purported_receive_chain_key_string, "purported_receive_chain_key");
 	mcJSON *purported_receive_chain_key = mcJSON_GetObjectItem(chain_keys, purported_receive_chain_key_string);
-	if ((send_chain_key == NULL) || (send_chain_key->type != mcJSON_String) || (send_chain_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))
-			|| (receive_chain_key == NULL) || (receive_chain_key->type != mcJSON_String) || (receive_chain_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))
-			|| (purported_receive_chain_key == NULL) || (purported_receive_chain_key->type != mcJSON_String) || (purported_receive_chain_key->valuestring->content_length != (2 * crypto_secretbox_KEYBYTES + 1))) {
+	if ((send_chain_key == NULL) || (send_chain_key->type != mcJSON_String) || (send_chain_key->valuestring->content_length != (2 * CHAIN_KEY_SIZE + 1))
+			|| (receive_chain_key == NULL) || (receive_chain_key->type != mcJSON_String) || (receive_chain_key->valuestring->content_length != (2 * CHAIN_KEY_SIZE + 1))
+			|| (purported_receive_chain_key == NULL) || (purported_receive_chain_key->type != mcJSON_String) || (purported_receive_chain_key->valuestring->content_length != (2 * CHAIN_KEY_SIZE + 1))) {
 			goto fail;
 	}
 
@@ -972,9 +973,9 @@ ratchet_state *ratchet_json_import(const mcJSON * const json) {
 	mcJSON *our_public_ephemeral = mcJSON_GetObjectItem(our_keys, public_ephemeral_string);
 	buffer_create_from_string(private_ephemeral_string, "private_ephemeral");
 	mcJSON *our_private_ephemeral = mcJSON_GetObjectItem(our_keys, private_ephemeral_string);
-	if ((our_public_identity == NULL) || (our_public_identity->type != mcJSON_String) || (our_public_identity->valuestring->content_length != (2 * crypto_box_PUBLICKEYBYTES + 1))
-			|| (our_public_ephemeral == NULL) || (our_public_ephemeral->type != mcJSON_String) || (our_public_ephemeral->valuestring->content_length != (2 * crypto_box_PUBLICKEYBYTES + 1))
-			|| (our_private_ephemeral == NULL) || (our_private_ephemeral->type != mcJSON_String) || (our_private_ephemeral->valuestring->content_length != (2 * crypto_box_SECRETKEYBYTES + 1))) {
+	if ((our_public_identity == NULL) || (our_public_identity->type != mcJSON_String) || (our_public_identity->valuestring->content_length != (2 * PUBLIC_KEY_SIZE + 1))
+			|| (our_public_ephemeral == NULL) || (our_public_ephemeral->type != mcJSON_String) || (our_public_ephemeral->valuestring->content_length != (2 * PUBLIC_KEY_SIZE + 1))
+			|| (our_private_ephemeral == NULL) || (our_private_ephemeral->type != mcJSON_String) || (our_private_ephemeral->valuestring->content_length != (2 * PRIVATE_KEY_SIZE + 1))) {
 		goto fail;
 	}
 
@@ -1000,9 +1001,9 @@ ratchet_state *ratchet_json_import(const mcJSON * const json) {
 	mcJSON *their_public_ephemeral = mcJSON_GetObjectItem(their_keys, public_ephemeral_string);
 	buffer_create_from_string(purported_public_ephemeral_string, "purported_public_ephemeral");
 	mcJSON *their_purported_public_ephemeral = mcJSON_GetObjectItem(their_keys, purported_public_ephemeral_string);
-	if ((their_public_identity == NULL) || (their_public_identity->type != mcJSON_String) || (their_public_identity->valuestring->content_length != (2 * crypto_box_PUBLICKEYBYTES + 1))
-			|| (their_public_ephemeral == NULL) || (their_public_ephemeral->type != mcJSON_String) || (their_public_ephemeral->valuestring->content_length != (2 * crypto_box_PUBLICKEYBYTES + 1))
-			|| (their_purported_public_ephemeral == NULL) || (their_purported_public_ephemeral->type != mcJSON_String) || (their_purported_public_ephemeral->valuestring->content_length != (2 * crypto_box_PUBLICKEYBYTES + 1))) {
+	if ((their_public_identity == NULL) || (their_public_identity->type != mcJSON_String) || (their_public_identity->valuestring->content_length != (2 * PUBLIC_KEY_SIZE + 1))
+			|| (their_public_ephemeral == NULL) || (their_public_ephemeral->type != mcJSON_String) || (their_public_ephemeral->valuestring->content_length != (2 * PUBLIC_KEY_SIZE + 1))
+			|| (their_purported_public_ephemeral == NULL) || (their_purported_public_ephemeral->type != mcJSON_String) || (their_purported_public_ephemeral->valuestring->content_length != (2 * PUBLIC_KEY_SIZE + 1))) {
 		goto fail;
 	}
 

--- a/lib/ratchet.h
+++ b/lib/ratchet.h
@@ -18,6 +18,7 @@
 
 #include <stdbool.h>
 
+#include "constants.h"
 #include "header-and-message-keystore.h"
 
 #ifndef LIB_RATCHET_H
@@ -33,43 +34,43 @@ typedef enum ratchet_header_decryptability {
 //struct that represents the state of a conversation
 typedef struct ratchet_state {
 	buffer_t root_key[1]; //RK
-	const unsigned char root_key_storage[crypto_secretbox_KEYBYTES];
+	const unsigned char root_key_storage[ROOT_KEY_SIZE];
 	buffer_t purported_root_key[1]; //RKp
-	const unsigned char purported_root_key_storage[crypto_secretbox_KEYBYTES];
+	const unsigned char purported_root_key_storage[ROOT_KEY_SIZE];
 	//header keys
 	buffer_t send_header_key[1];
-	const unsigned char send_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char send_header_key_storage[HEADER_KEY_SIZE];
 	buffer_t receive_header_key[1];
-	const unsigned char receive_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char receive_header_key_storage[HEADER_KEY_SIZE];
 	buffer_t next_send_header_key[1];
-	const unsigned char next_send_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char next_send_header_key_storage[HEADER_KEY_SIZE];
 	buffer_t next_receive_header_key[1];
-	const unsigned char next_receive_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char next_receive_header_key_storage[HEADER_KEY_SIZE];
 	buffer_t purported_receive_header_key[1];
-	const unsigned char purported_receive_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char purported_receive_header_key_storage[HEADER_KEY_SIZE];
 	buffer_t purported_next_receive_header_key[1];
-	const unsigned char purported_next_receive_header_key_storage[crypto_aead_chacha20poly1305_KEYBYTES];
+	const unsigned char purported_next_receive_header_key_storage[HEADER_KEY_SIZE];
 	//chain keys
 	buffer_t send_chain_key[1]; //CKs
-	const unsigned char send_chain_key_storage[crypto_secretbox_KEYBYTES];
+	const unsigned char send_chain_key_storage[CHAIN_KEY_SIZE];
 	buffer_t receive_chain_key[1]; //CKr
-	const unsigned char receive_chain_key_storage[crypto_secretbox_KEYBYTES];
+	const unsigned char receive_chain_key_storage[CHAIN_KEY_SIZE];
 	buffer_t purported_receive_chain_key[1]; //CKp
-	const unsigned char purported_receive_chain_key_storage[crypto_secretbox_KEYBYTES];
+	const unsigned char purported_receive_chain_key_storage[CHAIN_KEY_SIZE];
 	//identity keys
 	buffer_t our_public_identity[1]; //DHIs
-	const unsigned char our_public_identity_storage[crypto_box_PUBLICKEYBYTES];
+	const unsigned char our_public_identity_storage[PUBLIC_KEY_SIZE];
 	buffer_t their_public_identity[1]; //DHIr
-	const unsigned char their_public_identity_storage[crypto_box_PUBLICKEYBYTES];
+	const unsigned char their_public_identity_storage[PUBLIC_KEY_SIZE];
 	//ephemeral keys (ratchet keys)
 	buffer_t our_private_ephemeral[1]; //DHRs
-	const unsigned char our_private_ephemeral_storage[crypto_box_SECRETKEYBYTES];
+	const unsigned char our_private_ephemeral_storage[PRIVATE_KEY_SIZE];
 	buffer_t our_public_ephemeral[1]; //DHRs
-	const unsigned char our_public_ephemeral_storage[crypto_box_PUBLICKEYBYTES];
+	const unsigned char our_public_ephemeral_storage[PUBLIC_KEY_SIZE];
 	buffer_t their_public_ephemeral[1]; //DHRr
-	const unsigned char their_public_ephemeral_storage[crypto_box_PUBLICKEYBYTES];
+	const unsigned char their_public_ephemeral_storage[PUBLIC_KEY_SIZE];
 	buffer_t their_purported_public_ephemeral[1]; //DHp
-	const unsigned char their_purported_public_ephemeral_storage[crypto_box_PUBLICKEYBYTES];
+	const unsigned char their_purported_public_ephemeral_storage[PUBLIC_KEY_SIZE];
 	//message numbers
 	unsigned int send_message_number; //Ns
 	unsigned int receive_message_number; //Nr
@@ -108,9 +109,9 @@ ratchet_state* ratchet_create(
  * Create message and header keys to encrypt the next send message with.
  */
 int ratchet_next_send_keys(
-		buffer_t * const next_message_key, //crypto_secretbox_KEYBYTES
+		buffer_t * const next_message_key, //MESSAGE_KEY_SIZE
 		                     //from the ratchet_state struct
-		buffer_t * const next_header_key, //crypto_aead_chacha20poly1305_KEYBYTES
+		buffer_t * const next_header_key, //HEADER_KEY_SIZE
 		ratchet_state *state) __attribute__((warn_unused_result));
 
 /*

--- a/lib/spiced-random.c
+++ b/lib/spiced-random.c
@@ -19,6 +19,7 @@
 #include <sodium.h>
 #include <assert.h>
 
+#include "constants.h"
 #include "spiced-random.h"
 
 /*

--- a/lib/user-store.h
+++ b/lib/user-store.h
@@ -36,15 +36,15 @@ struct user_store_node {
 	user_store_node *previous;
 	user_store_node *next;
 	buffer_t public_identity_key[1];
-	unsigned char public_identity_key_storage[crypto_box_PUBLICKEYBYTES];
+	unsigned char public_identity_key_storage[PUBLIC_KEY_SIZE];
 	buffer_t private_identity_key[1];
-	unsigned char private_identity_key_storage[crypto_box_SECRETKEYBYTES];
+	unsigned char private_identity_key_storage[PRIVATE_KEY_SIZE];
 	//FIXME those prekey should be replaced by it's own prekey store in the future
 	//(this allows still having old prekeys around)
 	buffer_t public_prekeys[PREKEY_AMOUNT];
-	unsigned char public_prekey_storage[PREKEY_AMOUNT * crypto_box_PUBLICKEYBYTES];
+	unsigned char public_prekey_storage[PREKEY_AMOUNT * PUBLIC_KEY_SIZE];
 	buffer_t private_prekeys[PREKEY_AMOUNT];
-	unsigned char private_prekey_storage[PREKEY_AMOUNT * crypto_box_SECRETKEYBYTES];
+	unsigned char private_prekey_storage[PREKEY_AMOUNT * PRIVATE_KEY_SIZE];
 	conversation_store conversations[1];
 };
 

--- a/lib/user-store.h
+++ b/lib/user-store.h
@@ -19,14 +19,13 @@
 #include <sodium.h>
 #include <time.h>
 
+#include "constants.h"
 #include "../buffer/buffer.h"
 #include "../mcJSON/mcJSON.h"
 #include "conversation-store.h"
 
 #ifndef LIB_USER_STORE_H
 #define LIB_USER_STORE_H
-
-#define PREKEY_AMOUNT 100
 
 //The user store stores a linked list of all users identified by their private keys
 //This linked list is supposed to be stored once in a global variable.


### PR DESCRIPTION
This defines constants as aliases for libsodiums keylengths and some other values with global impact in one header file that can be used everywhere.

See #9