### PR TITLE
Implement tracing functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ static-analysis/
 address-sanitizer
 undefined-behavior-sanitizer
 *.swp
+tracing/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,15 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
 
 enable_testing()
 
+option(TRACING "Enable tracing." OFF)
+if (TRACING)
+    message("TRACING ENABLED")
+    add_definitions(-DTRACING)
+    add_library(tracing "test/tracing")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -finstrument-functions -finstrument-functions-exclude-function-list=printf,dladdr")
+    set(CMAKE_C_LINK_FLAGS "${CMAKE_C_LINK_FLAGS} -ldl")
+endif()
+
 #check if running debug build
 if ("${CMAKE_BUILD_TYPE}" MATCHES "Debug")
     if ("${CMAKE_C_COMPILER}" MATCHES "clang")

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,6 +26,7 @@ other practices
   - if you're creating new files, add a new test file in the `test` directory and add it to `test/CMakeLists.txt`
 * add `__attribute__((warn_unused_result))` to functions that return error codes or pointers to heap allocated memory
 * ensure that all resources are freed once you leave a function (even when errors occur)
+* make sure that every test includes `tracing.h`
 
 git usage
 ---------

--- a/README.md
+++ b/README.md
@@ -49,6 +49,19 @@ $ scan-build make
 ```
 or run the script `ci/clang-static-analysis.sh`.
 
+how to generate traces for debugging
+------------------------------------
+```
+$ mkdir tracing
+$ cd tracing
+$ cmake .. -DCMAKE_BUILD_TYPE=Debug -DTRACING=On
+$ make
+```
+
+Now, when you run one of the tests (those are located at `tracing/test/`), it will generate a file `trace.out` and print all function calls to stdout.
+
+You can postprocess this tracing output with `test/trace.lua`, pass it the path of `trace.out`, or the path to a saved output of the test and it will pretty-print the trace. It can also filter out function calls to make things easier to read, see it's source code for more details.
+
 size of a packet
 ----------------
 NOTE: This may be subject to change.

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required (VERSION 2.6)
 
 add_library(utils utils)
 target_link_libraries(utils molch-buffer)
+if (TRACING)
+    target_link_libraries(utils tracing)
+endif()
 
 add_library(common common)
 target_link_libraries(common utils)

--- a/test/chain-key-derivation-test.c
+++ b/test/chain-key-derivation-test.c
@@ -22,6 +22,7 @@
 
 #include "../lib/key-derivation.h"
 #include "utils.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/conversation-store-test.c
+++ b/test/conversation-store-test.c
@@ -25,6 +25,7 @@
 #include "../lib/conversation-store.h"
 #include "../lib/json.h"
 #include "utils.h"
+#include "tracing.h"
 
 int test_add_conversation(conversation_store * const store) {
 	//define key buffers

--- a/test/conversation-test.c
+++ b/test/conversation-test.c
@@ -25,6 +25,7 @@
 #include "common.h"
 #include "../lib/conversation.h"
 #include "../lib/json.h"
+#include "tracing.h"
 
 int main(void) {
 	int status = sodium_init();

--- a/test/diffie-hellman-test.c
+++ b/test/diffie-hellman-test.c
@@ -22,6 +22,7 @@
 #include "../lib/diffie-hellman.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/header-and-message-keystore-test.c
+++ b/test/header-and-message-keystore-test.c
@@ -24,6 +24,7 @@
 #include "../lib/json.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 
 int main(void) {

--- a/test/header-test.c
+++ b/test/header-test.c
@@ -21,6 +21,7 @@
 
 #include "../lib/header.h"
 #include "utils.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/initial-root-chain-and-header-key-derivation-test.c
+++ b/test/initial-root-chain-and-header-key-derivation-test.c
@@ -22,6 +22,7 @@
 #include "../lib/key-derivation.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/list-test.c
+++ b/test/list-test.c
@@ -21,6 +21,7 @@
 #include <assert.h>
 
 #include "../lib/list.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/message-key-derivation-test.c
+++ b/test/message-key-derivation-test.c
@@ -22,6 +22,7 @@
 
 #include "../lib/key-derivation.h"
 #include "utils.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/molch-test.c
+++ b/test/molch-test.c
@@ -22,6 +22,7 @@
 #include "utils.h"
 #include "../lib/molch.h"
 #include "../lib/user-store.h" //for PREKEY_AMOUNT
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/packet-decrypt-header-test.c
+++ b/test/packet-decrypt-header-test.c
@@ -22,6 +22,7 @@
 #include "../lib/packet.h"
 #include "utils.h"
 #include "packet-test-lib.h"
+#include "tracing.h"
 
 int main(void) {
 	if(sodium_init() == -1) {

--- a/test/packet-decrypt-message-test.c
+++ b/test/packet-decrypt-message-test.c
@@ -22,6 +22,7 @@
 #include "../lib/packet.h"
 #include "utils.h"
 #include "packet-test-lib.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/packet-decrypt-test.c
+++ b/test/packet-decrypt-test.c
@@ -22,6 +22,7 @@
 #include "../lib/packet.h"
 #include "utils.h"
 #include "packet-test-lib.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/packet-get-metadata-test.c
+++ b/test/packet-get-metadata-test.c
@@ -22,6 +22,7 @@
 #include "../lib/packet.h"
 #include "utils.h"
 #include "packet-test-lib.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/packet-test-lib.c
+++ b/test/packet-test-lib.c
@@ -22,6 +22,7 @@
 #include "../lib/packet.h"
 #include "utils.h"
 #include "packet-test-lib.h"
+#include "tracing.h"
 
 /*
  * Create message and header keys, encrypt header and message

--- a/test/ratchet-test.c
+++ b/test/ratchet-test.c
@@ -25,6 +25,7 @@
 #include "../lib/json.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/root-chain-and-header-key-derivation-test.c
+++ b/test/root-chain-and-header-key-derivation-test.c
@@ -22,6 +22,7 @@
 #include "../lib/key-derivation.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/spiced-random-test.c
+++ b/test/spiced-random-test.c
@@ -21,6 +21,7 @@
 
 #include "../lib/spiced-random.h"
 #include "utils.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/trace.lua
+++ b/test/trace.lua
@@ -1,0 +1,62 @@
+#!/usr/bin/env lua
+
+--[[
+-- This is a small lua script to convert the output of tracing.c into
+-- a somewhat more readable form and be able to filter out some functions
+--
+--  Copyright (C) 2016  Max Bruckner (FSMaxB)
+--
+--  This library is free software; you can redistribute it and/or
+--  modify it under the terms of the GNU Lesser General Public
+--  License as published by the Free Software Foundation; either
+--  version 2.1 of the License, or (at your option) any later version.
+--
+--  This library is distributed in the hope that it will be useful,
+--  but WITHOUT ANY WARRANTY; without even the implied warranty of
+--  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+--  Lesser General Public License for more details.
+--
+--  You should have received a copy of the GNU Lesser General Public
+--  License along with this library; if not, write to the Free Software
+--  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+--]]
+
+local trace_file = arg[1] or "trace.out"
+
+local pattern = "^(%d+) ([%a_%(%)]+) ([%-<>]+) ([%a_%(%)]+)$"
+
+-- functions that should be ignored
+local ignore_list = {
+	putchar = true
+}
+
+local indentation_strings = {
+	deepest_level = 0,
+	[0] = ""
+}
+local function indentation_string(level)
+	for i = indentation_strings.deepest_level + 1, level do
+		indentation_strings[i] = indentation_strings[i - 1] .. "    "
+	end
+
+	return indentation_strings[level]
+end
+
+-- go trough the file line by line
+for line in io.lines(trace_file) do
+	local level, caller, direction, callee = line:match(pattern)
+
+	if not level then -- not a valid trace line, treat as program output
+		print("> "..line)
+	elseif ignore_list[callee] then
+	else
+		level = tonumber(level)
+		if direction == "->" then
+			print(indentation_string(level + 1)..callee)
+		elseif direction == "<-" then
+			print(indentation_string(level)..caller)
+		else
+			print("> "..line) -- treat as program output
+		end
+	end
+end

--- a/test/tracing.c
+++ b/test/tracing.c
@@ -1,0 +1,79 @@
+/* Molch, an implementation of the axolotl ratchet based on libsodium
+ *  Copyright (C) 2016  Max Bruckner (FSMaxB)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *
+ * This file incorporates work by Balau, see https://balau82.wordpress.com/2010/10/06/trace-and-profile-function-calls-with-gcc/
+ */
+
+#ifdef TRACING
+#include <stdio.h>
+#include <stdbool.h>
+#include <limits.h>
+#define __USE_GNU
+#include <dlfcn.h>
+#include "tracing.h"
+
+static FILE *trace_file = NULL;
+//level of how deeply the function call was nested
+//starts with UINT_MAX so that the first level is 0
+static unsigned int current_level = UINT_MAX;
+
+void trace_begin(void) {
+	trace_file = fopen("trace.out", "w");
+	if (trace_file != NULL) {
+		printf("Writing trace of the execution to \"trace.out\".\n");
+	}
+}
+
+void trace_end(void) {
+	if (trace_file != NULL) {
+		fclose(trace_file);
+		printf("Trace of execution written to \"trace.out\".\n");
+	}
+}
+
+void __cyg_profile_func_enter(void *function, void *caller) {
+	current_level++;
+
+	Dl_info function_info;
+	Dl_info caller_info;
+	bool function_info_available = dladdr(function, &function_info);
+	bool caller_info_available = dladdr(caller, &caller_info);
+	if (function_info_available && caller_info_available) {
+		printf("%u %s -> %s\n", current_level, caller_info.dli_sname, function_info.dli_sname);
+	}
+
+	if ((trace_file != NULL) && function_info_available && caller_info_available) {
+		fprintf(trace_file, "%u %s -> %s\n", current_level, caller_info.dli_sname, function_info.dli_sname);
+	}
+}
+
+void __cyg_profile_func_exit(void *function, void *caller) {
+	Dl_info function_info;
+	Dl_info caller_info;
+	bool function_info_available = dladdr(function, &function_info);
+	bool caller_info_available = dladdr(caller, &caller_info);
+	if (function_info_available && caller_info_available) {
+	    printf("%u %s <- %s\n", current_level, caller_info.dli_sname, function_info.dli_sname);
+	}
+
+	if ((trace_file != NULL) && function_info_available && caller_info_available) {
+		fprintf(trace_file, "%u %s <- %s\n", current_level, caller_info.dli_sname, function_info.dli_sname);
+	}
+	current_level--;
+}
+#endif

--- a/test/tracing.h
+++ b/test/tracing.h
@@ -1,0 +1,34 @@
+/* Molch, an implementation of the axolotl ratchet based on libsodium
+ *  Copyright (C) 2016  Max Bruckner (FSMaxB)
+ *
+ *  This library is free software; you can redistribute it and/or
+ *  modify it under the terms of the GNU Lesser General Public
+ *  License as published by the Free Software Foundation; either
+ *  version 2.1 of the License, or (at your option) any later version.
+ *
+ *  This library is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ *  Lesser General Public License for more details.
+ *
+ *  You should have received a copy of the GNU Lesser General Public
+ *  License along with this library; if not, write to the Free Software
+ *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ *
+ * This file incorporates work by Balau, see https://balau82.wordpress.com/2010/10/06/trace-and-profile-function-calls-with-gcc/
+ */
+
+//This enables the creation of traces for debug purposes
+
+#ifdef TRACING
+
+#ifndef TEST_TRACING
+#define TEST_TRACING
+void trace_begin(void) __attribute__((constructor)) __attribute__((no_instrument_function));
+void trace_end(void) __attribute__((destructor)) __attribute__((no_instrument_function));
+void __cyg_profile_func_enter(void *function, void *caller) __attribute__((no_instrument_function));
+void __cyg_profile_func_exit(void *function, void *caller) __attribute__((no_instrument_function));
+#endif
+
+#endif

--- a/test/triple-diffie-hellman-test.c
+++ b/test/triple-diffie-hellman-test.c
@@ -22,6 +22,7 @@
 #include "../lib/diffie-hellman.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int main(void) {
 	if (sodium_init() == -1) {

--- a/test/user-store-test.c
+++ b/test/user-store-test.c
@@ -25,6 +25,7 @@
 #include "../lib/json.h"
 #include "utils.h"
 #include "common.h"
+#include "tracing.h"
 
 int generate_prekeys(buffer_t * const private_prekeys, buffer_t * const public_prekeys) {
 	if ((private_prekeys->buffer_length != (PREKEY_AMOUNT * crypto_box_SECRETKEYBYTES))


### PR DESCRIPTION
This introduces the possibility to trace the program execution (function calls only) when using the GCC compiler with glibc as standard library.

It can be enabled by passing `-DTRACING=on` to cmake as a command line flag.

This will instrument the generated binaries so that they write tracing data to stderr and into a file named `trace.out`.